### PR TITLE
fixed issue that top frame on stack gets thrown away

### DIFF
--- a/msos/MixedStack.cs
+++ b/msos/MixedStack.cs
@@ -258,7 +258,7 @@ namespace msos
                             found = true;
                             break;
                         }
-                        else if (managedFrame > 0)
+                        else if(managedFrame == 0)
                         {
                             // We have already seen at least one managed frame, and we're about
                             // to skip a managed frame because we didn't find a matching native

--- a/msos/MixedStack.cs
+++ b/msos/MixedStack.cs
@@ -260,7 +260,7 @@ namespace msos
                         }
                         else if(managedFrame == 0)
                         {
-                            // We have already seen at least one managed frame, and we're about
+                            // We're about
                             // to skip a managed frame because we didn't find a matching native
                             // frame. In this case, add the managed frame into the stack anyway.
                             unifiedStackTrace.Add(managedStackTrace[temp]);


### PR DESCRIPTION
when there was a managed frame at the top of the stack and no native one associated with, the frame could get thrown away, which would not be correct.
