### PR TITLE
Detect `Thread.Sleep` and Win32 `Sleep/SleepEx` as blocking objects 

### DIFF
--- a/msos/MixedStack.cs
+++ b/msos/MixedStack.cs
@@ -548,9 +548,10 @@ namespace msos
         {
             UnifiedBlockingReason result = UnifiedBlockingReason.Unknown;
 
-            switch (objectType)
+             switch (objectType)
             {
                 case "Thread": result = UnifiedBlockingReason.Thread; break;
+                case "ThreadSleep": result = UnifiedBlockingReason.ThreadSleep; break;
                 case "Job": result = UnifiedBlockingReason.Job; break;
                 case "File": result = UnifiedBlockingReason.File; break;
                 case "Semaphore": result = UnifiedBlockingReason.Semaphore; break;
@@ -625,6 +626,7 @@ namespace msos
         Semaphore = 21,
         Event = 22,        
         Timer = 23,
-        MemorySection = 24
+        MemorySection = 24,
+        ThreadSleep = 35
     }
 }

--- a/msos/MixedStack.cs
+++ b/msos/MixedStack.cs
@@ -517,6 +517,15 @@ namespace msos
             Reason = ConvertToUnified(objectType);
         }
 
+        public UnifiedBlockingObject(long sleepWait) : this(BlockingObjectOrigin.StackWalker)
+        {
+            Type = UnifiedBlockingType.UnmanagedHandleObject;
+            Reason = UnifiedBlockingReason.ThreadSleep;
+            SleepWait = sleepWait;
+        }
+
+        public long? SleepWait { get; set; }
+
         public BlockingObjectOrigin Origin { get; private set; }
 
         public UnifiedBlockingType Type { get; private set; }
@@ -551,6 +560,7 @@ namespace msos
             switch (objectType)
             {
                 case "Thread": result = UnifiedBlockingReason.Thread; break;
+                case "ThreadSleep": result = UnifiedBlockingReason.ThreadSleep; break;
                 case "Job": result = UnifiedBlockingReason.Job; break;
                 case "File": result = UnifiedBlockingReason.File; break;
                 case "Semaphore": result = UnifiedBlockingReason.Semaphore; break;
@@ -625,6 +635,7 @@ namespace msos
         Semaphore = 21,
         Event = 22,        
         Timer = 23,
-        MemorySection = 24
+        MemorySection = 24,
+        ThreadSleep = 25
     }
 }

--- a/msos/MixedStack.cs
+++ b/msos/MixedStack.cs
@@ -517,13 +517,12 @@ namespace msos
             Reason = ConvertToUnified(objectType);
         }
 
-        public UnifiedBlockingObject(long sleepWait) : this(BlockingObjectOrigin.StackWalker)
+        public UnifiedBlockingObject(long msTimeout) : this(BlockingObjectOrigin.StackWalker)
         {
             Type = UnifiedBlockingType.ThreadSleep;
-            SleepWait = sleepWait;
+            Reason = UnifiedBlockingReason.ThreadWait;
+            ReasonDescription = $"MsTimeout : {msTimeout}";
         }
-
-        public long? SleepWait { get; set; }
 
         public BlockingObjectOrigin Origin { get; private set; }
 
@@ -534,6 +533,8 @@ namespace msos
         public bool HasOwnershipInformation => OwnerOSThreadIds.Count > 0;
 
         public UnifiedBlockingReason Reason { get; private set; } = UnifiedBlockingReason.Unknown;
+
+        public string ReasonDescription { get; private set; }
 
         public List<uint> WaiterOSThreadIds { get; } = new List<uint>();
 

--- a/msos/MixedStack.cs
+++ b/msos/MixedStack.cs
@@ -423,7 +423,7 @@ namespace msos
 
     enum UnifiedBlockingType
     {
-        WaitChainInfoObject, ClrBlockingObject, DumpHandle, CriticalSectionObject, UnmanagedHandleObject
+        WaitChainInfoObject, ClrBlockingObject, DumpHandle, CriticalSectionObject, UnmanagedHandleObject, ThreadSleep
     }
 
     enum BlockingObjectOrigin
@@ -516,6 +516,14 @@ namespace msos
             Type = UnifiedBlockingType.UnmanagedHandleObject;
             Reason = ConvertToUnified(objectType);
         }
+
+        public UnifiedBlockingObject(long sleepWait) : this(BlockingObjectOrigin.StackWalker)
+        {
+            Type = UnifiedBlockingType.ThreadSleep;
+            SleepWait = sleepWait;
+        }
+
+        public long? SleepWait { get; set; }
 
         public BlockingObjectOrigin Origin { get; private set; }
 

--- a/msos/MixedStack.cs
+++ b/msos/MixedStack.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using static msos.NativeStructs;
 
 namespace msos
@@ -521,7 +522,7 @@ namespace msos
         {
             Type = UnifiedBlockingType.ThreadSleep;
             Reason = UnifiedBlockingReason.ThreadWait;
-            ReasonDescription = $"MsTimeout : {msTimeout}";
+            ReasonDescription = msTimeout == Timeout.Infinite ? $"Sleep with no timeout" : $"Sleep with timeout: {msTimeout}ms" ;
         }
 
         public BlockingObjectOrigin Origin { get; private set; }

--- a/msos/MixedStack.cs
+++ b/msos/MixedStack.cs
@@ -423,7 +423,7 @@ namespace msos
 
     enum UnifiedBlockingType
     {
-        WaitChainInfoObject, ClrBlockingObject, DumpHandle, CriticalSectionObject, UnmanagedHandleObject
+        WaitChainInfoObject, ClrBlockingObject, DumpHandle, CriticalSectionObject, UnmanagedHandleObject, ThreadSleep
     }
 
     enum BlockingObjectOrigin
@@ -519,8 +519,7 @@ namespace msos
 
         public UnifiedBlockingObject(long sleepWait) : this(BlockingObjectOrigin.StackWalker)
         {
-            Type = UnifiedBlockingType.UnmanagedHandleObject;
-            Reason = UnifiedBlockingReason.ThreadSleep;
+            Type = UnifiedBlockingType.ThreadSleep;
             SleepWait = sleepWait;
         }
 
@@ -560,7 +559,6 @@ namespace msos
             switch (objectType)
             {
                 case "Thread": result = UnifiedBlockingReason.Thread; break;
-                case "ThreadSleep": result = UnifiedBlockingReason.ThreadSleep; break;
                 case "Job": result = UnifiedBlockingReason.Job; break;
                 case "File": result = UnifiedBlockingReason.File; break;
                 case "Semaphore": result = UnifiedBlockingReason.Semaphore; break;
@@ -635,7 +633,6 @@ namespace msos
         Semaphore = 21,
         Event = 22,        
         Timer = 23,
-        MemorySection = 24,
-        ThreadSleep = 25
+        MemorySection = 24
     }
 }

--- a/msos/MixedStack.cs
+++ b/msos/MixedStack.cs
@@ -548,10 +548,9 @@ namespace msos
         {
             UnifiedBlockingReason result = UnifiedBlockingReason.Unknown;
 
-             switch (objectType)
+            switch (objectType)
             {
                 case "Thread": result = UnifiedBlockingReason.Thread; break;
-                case "ThreadSleep": result = UnifiedBlockingReason.ThreadSleep; break;
                 case "Job": result = UnifiedBlockingReason.Job; break;
                 case "File": result = UnifiedBlockingReason.File; break;
                 case "Semaphore": result = UnifiedBlockingReason.Semaphore; break;
@@ -626,7 +625,6 @@ namespace msos
         Semaphore = 21,
         Event = 22,        
         Timer = 23,
-        MemorySection = 24,
-        ThreadSleep = 35
+        MemorySection = 24
     }
 }

--- a/msos/NativeStructs.cs
+++ b/msos/NativeStructs.cs
@@ -51,17 +51,17 @@ namespace msos
 
         #region NtDll
 
-
-        //[StructLayout(LayoutKind.Explicit, Size = 8)]
+        [StructLayout(LayoutKind.Explicit, Size = 8)]
         public struct LARGE_INTEGER
         {
-            //[FieldOffset(0)]
-            //public Int64 QuadPart;
-            //[FieldOffset(0)]
-            //public UInt32 LowPart;
-            //[FieldOffset(4)]
-            //public Int32 HighPart;
+            [FieldOffset(0)]
             public Int64 QuadPart;
+            [FieldOffset(0)]
+            public UInt32 LowPart;
+            [FieldOffset(4)]
+            public Int32 HighPart;
+        }
+
             public Int32 HighPart;
         }
 

--- a/msos/NativeStructs.cs
+++ b/msos/NativeStructs.cs
@@ -52,16 +52,7 @@ namespace msos
         #region NtDll
 
         [StructLayout(LayoutKind.Explicit, Size = 8)]
-        public struct LARGE_INTEGER
-        {
-            [FieldOffset(0)]
-            public Int64 QuadPart;
-            [FieldOffset(0)]
-            public UInt32 LowPart;
-            [FieldOffset(4)]
-            public Int32 HighPart;
-        }
-        
+
         public unsafe struct PUBLIC_OBJECT_TYPE_INFORMATION
         {
             public UNICODE_STRING TypeName;

--- a/msos/NativeStructs.cs
+++ b/msos/NativeStructs.cs
@@ -51,6 +51,20 @@ namespace msos
 
         #region NtDll
 
+
+        //[StructLayout(LayoutKind.Explicit, Size = 8)]
+        public struct LARGE_INTEGER
+        {
+            //[FieldOffset(0)]
+            //public Int64 QuadPart;
+            //[FieldOffset(0)]
+            //public UInt32 LowPart;
+            //[FieldOffset(4)]
+            //public Int32 HighPart;
+            public Int64 QuadPart;
+            public Int32 HighPart;
+        }
+
         public unsafe struct PUBLIC_OBJECT_TYPE_INFORMATION
         {
             public UNICODE_STRING TypeName;

--- a/msos/NativeStructs.cs
+++ b/msos/NativeStructs.cs
@@ -51,8 +51,6 @@ namespace msos
 
         #region NtDll
 
-        [StructLayout(LayoutKind.Explicit, Size = 8)]
-
         public unsafe struct PUBLIC_OBJECT_TYPE_INFORMATION
         {
             public UNICODE_STRING TypeName;

--- a/msos/NativeStructs.cs
+++ b/msos/NativeStructs.cs
@@ -51,6 +51,17 @@ namespace msos
 
         #region NtDll
 
+        [StructLayout(LayoutKind.Explicit, Size = 8)]
+        public struct LARGE_INTEGER
+        {
+            [FieldOffset(0)]
+            public Int64 QuadPart;
+            [FieldOffset(0)]
+            public UInt32 LowPart;
+            [FieldOffset(4)]
+            public Int32 HighPart;
+        }
+        
         public unsafe struct PUBLIC_OBJECT_TYPE_INFORMATION
         {
             public UNICODE_STRING TypeName;

--- a/msos/NativeStructs.cs
+++ b/msos/NativeStructs.cs
@@ -61,10 +61,7 @@ namespace msos
             [FieldOffset(4)]
             public Int32 HighPart;
         }
-
-            public Int32 HighPart;
-        }
-
+        
         public unsafe struct PUBLIC_OBJECT_TYPE_INFORMATION
         {
             public UNICODE_STRING TypeName;

--- a/msos/StackWalker.cs
+++ b/msos/StackWalker.cs
@@ -162,7 +162,7 @@ namespace msos
             return result;
         }
 
-        protected bool IsMatchingMethod(UnifiedStackFrame frame, string key)
+        private bool IsMatchingMethod(UnifiedStackFrame frame, string key)
         {
             return frame?.Method == key;
         }
@@ -172,9 +172,7 @@ namespace msos
             blockingObject = null;
 
             if (IsMatchingMethod(frame, NTDELAY_EXECUTION_FUNCTION_NAME))
-            {
                 blockingObject = GetNtDelayExecutionBlockingObject(frame);
-            }
 
             return blockingObject != null;
         }
@@ -185,9 +183,7 @@ namespace msos
             blockingObject = null;
 
             if (frame.Handles != null && IsMatchingMethod(frame, ENTER_CRITICAL_SECTION_FUNCTION_NAME))
-            {
                 blockingObject = GetCriticalSectionBlockingObject(frame);
-            }
            
             return blockingObject != null;
         }

--- a/msos/StackWalker.cs
+++ b/msos/StackWalker.cs
@@ -93,7 +93,7 @@ namespace msos
             {
                 var handle = ConvertToAddress(parameters[0]);
                 
-                UnifiedHandle unifiedHandle = new UnifiedHandle(handle, frame.Method, null);
+                UnifiedHandle unifiedHandle = new UnifiedHandle(handle, nameof(UnifiedBlockingReason.ThreadSleep), null);
                 frame.Handles.Add(unifiedHandle);
             }
         }
@@ -191,7 +191,7 @@ namespace msos
                 return true;
             }
 
-            if (IsMatchingMethod(frame, SLEEP_FUNCTION_NAME) 
+            if (IsMatchingMethod(frame, SLEEP_FUNCTION_NAME)
                 || IsMatchingMethod(frame, SLEEPEX_FUNCTION_NAME)
                 || IsMatchingMethod(frame, THREAD_SLEEP_FUNCTION_NAME))
             {

--- a/msos/StackWalker.cs
+++ b/msos/StackWalker.cs
@@ -26,8 +26,8 @@ namespace msos
             var parameters = GetParameters(frame, NTDELAY_EXECUTION_FUNCTION_PARAM_COUNT);
             var largeIntegerAddress = ConvertToAddress(parameters[1]);
 
-            var largeInt = ReadStructureFromAddress<LARGE_INTEGER>(largeIntegerAddress);
-            var awaitMs = (-largeInt.QuadPart) / 10000;
+            var largeInt = ReadStructureFromAddress<Int64>(largeIntegerAddress);
+            var awaitMs = (-largeInt) / 10000;
 
             return new UnifiedBlockingObject(awaitMs);
         }

--- a/msos/StackWalker.cs
+++ b/msos/StackWalker.cs
@@ -85,18 +85,6 @@ namespace msos
                 AddSingleWaitInformation(frame, handle);
             }
         }
-
-        protected override void ExtractSleepObjectInformation(UnifiedStackFrame frame)
-        {
-            var parameters = GetParameters(frame, SLEEP_FUNCTION_OBJECT_PARAM_COUNT);
-            if (parameters.Count > 0)
-            {
-                var handle = ConvertToAddress(parameters[0]);
-                
-                UnifiedHandle unifiedHandle = new UnifiedHandle(handle, nameof(UnifiedBlockingReason.ThreadSleep), null);
-                frame.Handles.Add(unifiedHandle);
-            }
-        }
     }
 
     /// <summary>
@@ -111,11 +99,7 @@ namespace msos
         public const string WAIT_FOR_MULTIPLE_OBJECTS_FUNCTION_NAME = "WaitForMultipleObjects";
         public const string WAIT_FOR_MULTIPLE_OBJECTS_EX_FUNCTION_NAME = "WaitForMultipleObjectsEx";
         public const string ENTER_CRITICAL_SECTION_FUNCTION_NAME = "RtlEnterCriticalSection";
-        public const string THREAD_SLEEP_FUNCTION_NAME = "Thread.Sleep";
-        public const string SLEEP_FUNCTION_NAME = "SleepEx";
-        public const string SLEEPEX_FUNCTION_NAME = "SleepEx";
 
-        protected const int SLEEP_FUNCTION_OBJECT_PARAM_COUNT = 1;
         protected const int ENTER_CRITICAL_SECTION_FUNCTION_PARAM_COUNT = 1;
         protected const int WAIT_FOR_SINGLE_OBJECT_PARAM_COUNT = 2;
         protected const int WAIT_FOR_MULTIPLE_OBJECTS_PARAM_COUNT = 4;
@@ -191,14 +175,6 @@ namespace msos
                 return true;
             }
 
-            if (IsMatchingMethod(frame, SLEEP_FUNCTION_NAME)
-                || IsMatchingMethod(frame, SLEEPEX_FUNCTION_NAME)
-                || IsMatchingMethod(frame, THREAD_SLEEP_FUNCTION_NAME))
-            {
-                ExtractSleepObjectInformation(frame);
-                return true;
-            }
-
             return false;
         }
 
@@ -218,7 +194,7 @@ namespace msos
         {
             if (numberOfHandles > MAXIMUM_WAIT_OBJECTS)
                 numberOfHandles = MAXIMUM_WAIT_OBJECTS;
-                
+
             var handles = ReadHandles(addressOfHandlesArray, numberOfHandles);
             foreach (var handleBytes in handles)
             {
@@ -240,7 +216,6 @@ namespace msos
         }
 
         #region Abstract Methods
-        protected abstract void ExtractSleepObjectInformation(UnifiedStackFrame frame);
 
         protected abstract void ExtractWaitForSingleObjectInformation(UnifiedStackFrame frame);
 

--- a/msos/StackWalker.cs
+++ b/msos/StackWalker.cs
@@ -118,13 +118,8 @@ namespace msos
         public const string WAIT_FOR_MULTIPLE_OBJECTS_EX_FUNCTION_NAME = "WaitForMultipleObjectsEx";
         public const string ENTER_CRITICAL_SECTION_FUNCTION_NAME = "RtlEnterCriticalSection";
         public const string NTDELAY_EXECUTION_FUNCTION_NAME = "NtDelayExecution";
-
-        public const string THREAD_SLEEP_FUNCTION_NAME = "Sleep";
-        public const string SLEEP_FUNCTION_NAME = "SleepEx";
-        public const string SLEEPEX_FUNCTION_NAME = "SleepEx";
-
+        
         protected const int NTDELAY_EXECUTION_FUNCTION_PARAM_COUNT = 2;
-        protected const int SLEEP_FUNCTION_OBJECT_PARAM_COUNT = 1;
         protected const int ENTER_CRITICAL_SECTION_FUNCTION_PARAM_COUNT = 1;
         protected const int WAIT_FOR_SINGLE_OBJECT_PARAM_COUNT = 2;
         protected const int WAIT_FOR_MULTIPLE_OBJECTS_PARAM_COUNT = 4;

--- a/msos/StackWalker.cs
+++ b/msos/StackWalker.cs
@@ -27,7 +27,7 @@ namespace msos
             var largeIntegerAddress = ConvertToAddress(parameters[1]);
 
             var largeInt = ReadStructureFromAddress<LARGE_INTEGER>(largeIntegerAddress);
-            var awaitMs = ((-1) * largeInt.QuadPart) / 10000;
+            var awaitMs = (-largeInt.QuadPart) / 10000;
 
             return new UnifiedBlockingObject(awaitMs);
         }
@@ -49,7 +49,7 @@ namespace msos
             int read;
 
             if (!_runtime.ReadMemory(address, buffer, buffer.Length, out read) || read != buffer.Length)
-                throw new Exception($"Error reading structure data from address: {address}");
+                throw new Exception($"Error reading structure data from address: 0x{address.ToString("X")}");
 
             var gch = GCHandle.Alloc(buffer, GCHandleType.Pinned);
             try

--- a/msos/StackWalker.cs
+++ b/msos/StackWalker.cs
@@ -85,6 +85,18 @@ namespace msos
                 AddSingleWaitInformation(frame, handle);
             }
         }
+
+        protected override void ExtractSleepObjectInformation(UnifiedStackFrame frame)
+        {
+            var parameters = GetParameters(frame, SLEEP_FUNCTION_OBJECT_PARAM_COUNT);
+            if (parameters.Count > 0)
+            {
+                var handle = ConvertToAddress(parameters[0]);
+                
+                UnifiedHandle unifiedHandle = new UnifiedHandle(handle, frame.Method, null);
+                frame.Handles.Add(unifiedHandle);
+            }
+        }
     }
 
     /// <summary>
@@ -99,7 +111,11 @@ namespace msos
         public const string WAIT_FOR_MULTIPLE_OBJECTS_FUNCTION_NAME = "WaitForMultipleObjects";
         public const string WAIT_FOR_MULTIPLE_OBJECTS_EX_FUNCTION_NAME = "WaitForMultipleObjectsEx";
         public const string ENTER_CRITICAL_SECTION_FUNCTION_NAME = "RtlEnterCriticalSection";
+        public const string THREAD_SLEEP_FUNCTION_NAME = "Thread.Sleep";
+        public const string SLEEP_FUNCTION_NAME = "SleepEx";
+        public const string SLEEPEX_FUNCTION_NAME = "SleepEx";
 
+        protected const int SLEEP_FUNCTION_OBJECT_PARAM_COUNT = 1;
         protected const int ENTER_CRITICAL_SECTION_FUNCTION_PARAM_COUNT = 1;
         protected const int WAIT_FOR_SINGLE_OBJECT_PARAM_COUNT = 2;
         protected const int WAIT_FOR_MULTIPLE_OBJECTS_PARAM_COUNT = 4;
@@ -175,6 +191,14 @@ namespace msos
                 return true;
             }
 
+            if (IsMatchingMethod(frame, SLEEP_FUNCTION_NAME) 
+                || IsMatchingMethod(frame, SLEEPEX_FUNCTION_NAME)
+                || IsMatchingMethod(frame, THREAD_SLEEP_FUNCTION_NAME))
+            {
+                ExtractSleepObjectInformation(frame);
+                return true;
+            }
+
             return false;
         }
 
@@ -194,7 +218,7 @@ namespace msos
         {
             if (numberOfHandles > MAXIMUM_WAIT_OBJECTS)
                 numberOfHandles = MAXIMUM_WAIT_OBJECTS;
-
+                
             var handles = ReadHandles(addressOfHandlesArray, numberOfHandles);
             foreach (var handleBytes in handles)
             {
@@ -216,6 +240,7 @@ namespace msos
         }
 
         #region Abstract Methods
+        protected abstract void ExtractSleepObjectInformation(UnifiedStackFrame frame);
 
         protected abstract void ExtractWaitForSingleObjectInformation(UnifiedStackFrame frame);
 

--- a/msos/StackWalker.cs
+++ b/msos/StackWalker.cs
@@ -24,11 +24,9 @@ namespace msos
         internal override UnifiedBlockingObject GetNtDelayExecutionBlockingObject(UnifiedStackFrame frame)
         {
             var parameters = GetParameters(frame, NTDELAY_EXECUTION_FUNCTION_PARAM_COUNT);
-
             var largeIntegerAddress = ConvertToAddress(parameters[1]);
 
             var largeInt = ReadStructureFromAddress<LARGE_INTEGER>(largeIntegerAddress);
-
             var awaitMs = ((-1) * largeInt.QuadPart) / 10000;
 
             return new UnifiedBlockingObject(awaitMs);
@@ -37,11 +35,9 @@ namespace msos
         protected override UnifiedBlockingObject GetCriticalSectionBlockingObject(UnifiedStackFrame frame)
         {
             var parameters = GetParameters(frame, ENTER_CRITICAL_SECTION_FUNCTION_PARAM_COUNT);
-
             var criticalSectionAddress = ConvertToAddress(parameters[0]);
 
             var section = ReadStructureFromAddress<CRITICAL_SECTION>(criticalSectionAddress);
-
             return new UnifiedBlockingObject(section, criticalSectionAddress);
         }
 

--- a/msos/StackWalker.cs
+++ b/msos/StackWalker.cs
@@ -20,29 +20,51 @@ namespace msos
                 throw new Exception("Unexpected architecture: only X86 is supported");
         }
 
+
+        internal override UnifiedBlockingObject GetNtDelayExecutionBlockingObject(UnifiedStackFrame frame)
+        {
+            var parameters = GetParameters(frame, NTDELAY_EXECUTION_FUNCTION_PARAM_COUNT);
+
+            var largeIntegerAddress = ConvertToAddress(parameters[1]);
+
+            var largeInt = ReadStructureFromAddress<LARGE_INTEGER>(largeIntegerAddress);
+
+            var awaitMs = ((-1) * largeInt.QuadPart) / 10000;
+
+            return new UnifiedBlockingObject(awaitMs);
+        }
+
         protected override UnifiedBlockingObject GetCriticalSectionBlockingObject(UnifiedStackFrame frame)
         {
-            UnifiedBlockingObject result = null;
             var parameters = GetParameters(frame, ENTER_CRITICAL_SECTION_FUNCTION_PARAM_COUNT);
+
             var criticalSectionAddress = ConvertToAddress(parameters[0]);
 
-            byte[] buffer = new byte[Marshal.SizeOf(typeof(CRITICAL_SECTION))];
+            var section = ReadStructureFromAddress<CRITICAL_SECTION>(criticalSectionAddress);
+
+            return new UnifiedBlockingObject(section, criticalSectionAddress);
+        }
+
+        private T ReadStructureFromAddress<T>(ulong address)
+        {
+            T result = default(T);
+
+            byte[] buffer = new byte[Marshal.SizeOf(typeof(T))];
             int read;
 
-            if (!_runtime.ReadMemory(criticalSectionAddress, buffer, buffer.Length, out read) || read != buffer.Length)
-                throw new Exception($"Error reading critical section data from address: {criticalSectionAddress}");
+            if (!_runtime.ReadMemory(address, buffer, buffer.Length, out read) || read != buffer.Length)
+                throw new Exception($"Error reading structure data from address: {address}");
 
             var gch = GCHandle.Alloc(buffer, GCHandleType.Pinned);
             try
             {
-                CRITICAL_SECTION section = (CRITICAL_SECTION)Marshal.PtrToStructure(
-                    gch.AddrOfPinnedObject(), typeof(CRITICAL_SECTION));
-                result = new UnifiedBlockingObject(section, criticalSectionAddress);
+                result = Marshal.PtrToStructure<T>(gch.AddrOfPinnedObject());
             }
             finally
             {
                 gch.Free();
             }
+
             return result;
         }
 
@@ -99,7 +121,14 @@ namespace msos
         public const string WAIT_FOR_MULTIPLE_OBJECTS_FUNCTION_NAME = "WaitForMultipleObjects";
         public const string WAIT_FOR_MULTIPLE_OBJECTS_EX_FUNCTION_NAME = "WaitForMultipleObjectsEx";
         public const string ENTER_CRITICAL_SECTION_FUNCTION_NAME = "RtlEnterCriticalSection";
+        public const string NTDELAY_EXECUTION_FUNCTION_NAME = "NtDelayExecution";
 
+        public const string THREAD_SLEEP_FUNCTION_NAME = "Sleep";
+        public const string SLEEP_FUNCTION_NAME = "SleepEx";
+        public const string SLEEPEX_FUNCTION_NAME = "SleepEx";
+
+        protected const int NTDELAY_EXECUTION_FUNCTION_PARAM_COUNT = 2;
+        protected const int SLEEP_FUNCTION_OBJECT_PARAM_COUNT = 1;
         protected const int ENTER_CRITICAL_SECTION_FUNCTION_PARAM_COUNT = 1;
         protected const int WAIT_FOR_SINGLE_OBJECT_PARAM_COUNT = 2;
         protected const int WAIT_FOR_MULTIPLE_OBJECTS_PARAM_COUNT = 4;
@@ -137,26 +166,34 @@ namespace msos
             return result;
         }
 
-        private bool IsMatchingMethod(UnifiedStackFrame frame, string key)
+        protected bool IsMatchingMethod(UnifiedStackFrame frame, string key)
         {
             return frame?.Method == key;
         }
 
+        internal bool GetThreadSleepBlockingObject(UnifiedStackFrame frame, out UnifiedBlockingObject blockingObject)
+        {
+            blockingObject = null;
+
+            if (IsMatchingMethod(frame, NTDELAY_EXECUTION_FUNCTION_NAME))
+            {
+                blockingObject = GetNtDelayExecutionBlockingObject(frame);
+            }
+
+            return blockingObject != null;
+        }
+
+
         public bool GetCriticalSectionBlockingObject(UnifiedStackFrame frame, out UnifiedBlockingObject blockingObject)
         {
-            bool result = false;
+            blockingObject = null;
 
             if (frame.Handles != null && IsMatchingMethod(frame, ENTER_CRITICAL_SECTION_FUNCTION_NAME))
             {
                 blockingObject = GetCriticalSectionBlockingObject(frame);
-                result = blockingObject != null;
             }
-            else
-            {
-                blockingObject = null;
-            }
-
-            return result;
+           
+            return blockingObject != null;
         }
 
         public bool SetFrameParameters(UnifiedStackFrame frame)
@@ -220,6 +257,8 @@ namespace msos
         protected abstract void ExtractWaitForSingleObjectInformation(UnifiedStackFrame frame);
 
         protected abstract void ExtractWaitForMultipleObjectsInformation(UnifiedStackFrame frame);
+
+        internal abstract UnifiedBlockingObject GetNtDelayExecutionBlockingObject(UnifiedStackFrame frame);
 
         protected abstract UnifiedBlockingObject GetCriticalSectionBlockingObject(UnifiedStackFrame frame);
 

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace msos
 {
-    [SupportedTargets(TargetType.DumpFile, TargetType.LiveProcess, TargetType.DumpFileNoHeap)]
+    [SupportedTargets(TargetType.DumpFile, TargetType.LiveProcess)]
     [Verb("!waits", HelpText = "Displays wait chain information and detects deadlocks.")]
     class WaitChains : ICommand
     {
@@ -56,8 +56,7 @@ namespace msos
 
         private void SetStrategy()
         {
-            if (_context.TargetType == TargetType.DumpFileNoHeap 
-                || _context.TargetType == TargetType.DumpFileNoHeap)
+            if (_context.TargetType == TargetType.DumpFile)
             {
                 _temporaryDbgEngTarget = _context.CreateTemporaryDbgEngTarget();
                 _unifiedStackTraces = new UnifiedStackTraces(_temporaryDbgEngTarget.DebuggerInterface, _context);

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -68,7 +68,7 @@ namespace msos
             else
             {
                 _blockingObjectsStrategy = new LiveProcessBlockingObjectsStrategy(_context.Runtime);
-                
+
                 // Currently, we are only enumerating the managed threads because we don't have 
                 // an alternative source of information for threads in live processes. In the future,
                 // we can consider using System.Diagnostics or some other means of enumerating threads
@@ -214,10 +214,7 @@ namespace msos
                         else if (_stackWalker.GetThreadSleepBlockingObject(frame, out blockingObject))
                             result.Add(blockingObject);
 
-                        if (frame.Handles.Count > 0)
-                        {
-                            result.AddRange(frame.Handles.Select(GetUnifiedBlockingObjectForHandle));
-                        }
+                        result.AddRange(frame.Handles.Select(GetUnifiedBlockingObjectForHandle));
                     }
                 }
             }

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -56,7 +56,8 @@ namespace msos
 
         private void SetStrategy()
         {
-            if (_context.TargetType == TargetType.DumpFile)
+            if (_context.TargetType == TargetType.DumpFile
+                || _context.TargetType == TargetType.DumpFile)
             {
                 _temporaryDbgEngTarget = _context.CreateTemporaryDbgEngTarget();
                 _unifiedStackTraces = new UnifiedStackTraces(_temporaryDbgEngTarget.DebuggerInterface, _context);
@@ -67,7 +68,7 @@ namespace msos
             else
             {
                 _blockingObjectsStrategy = new LiveProcessBlockingObjectsStrategy(_context.Runtime);
-
+                
                 // Currently, we are only enumerating the managed threads because we don't have 
                 // an alternative source of information for threads in live processes. In the future,
                 // we can consider using System.Diagnostics or some other means of enumerating threads
@@ -107,10 +108,7 @@ namespace msos
         {
             foreach (var blockingObject in unifiedThread.BlockingObjects)
             {
-                string reason = blockingObject.Reason == UnifiedBlockingReason.ThreadSleep
-                                ? $"ThreadSleep {blockingObject.Handle}" : blockingObject.Reason.ToString();
-
-                _context.Write("{0}| {1} ", new string(' ', (depth + 1) * 2), reason);
+                _context.Write("{0}| {1} ", new string(' ', (depth + 1) * 2), blockingObject.Reason);
 
                 if (!String.IsNullOrEmpty(blockingObject.KernelObjectName))
                 {
@@ -205,7 +203,7 @@ namespace msos
                     foreach (var frame in stack)
                     {
                         _stackWalker.SetFrameParameters(frame);
-                            
+
                         UnifiedBlockingObject blockingObject;
                         if (_stackWalker.GetCriticalSectionBlockingObject(frame, out blockingObject))
                             result.Add(blockingObject);
@@ -229,7 +227,7 @@ namespace msos
         protected virtual UnifiedBlockingObject GetUnifiedBlockingObjectForHandle(UnifiedHandle handle)
         {
             return new UnifiedBlockingObject(handle.Value, handle.ObjectName, handle.Type);
-        }   
+        }
     }
 
 

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace msos
 {
-    [SupportedTargets(TargetType.DumpFile, TargetType.LiveProcess, TargetType.DumpFileNoHeap)]
+    [SupportedTargets(TargetType.DumpFile, TargetType.LiveProcess)]
     [Verb("!waits", HelpText = "Displays wait chain information and detects deadlocks.")]
     class WaitChains : ICommand
     {
@@ -57,7 +57,7 @@ namespace msos
         private void SetStrategy()
         {
             if (_context.TargetType == TargetType.DumpFile
-                || _context.TargetType == TargetType.DumpFileNoHeap)
+                || _context.TargetType == TargetType.DumpFile)
             {
                 _temporaryDbgEngTarget = _context.CreateTemporaryDbgEngTarget();
                 _unifiedStackTraces = new UnifiedStackTraces(_temporaryDbgEngTarget.DebuggerInterface, _context);
@@ -108,7 +108,11 @@ namespace msos
         {
             foreach (var blockingObject in unifiedThread.BlockingObjects)
             {
-                _context.Write("{0}| {1} ", new string(' ', (depth + 1) * 2), blockingObject.Reason);
+                string reason = blockingObject.Type == UnifiedBlockingType.ThreadSleep
+                                ? $"ThreadSleep: {blockingObject.SleepWait.Value}"
+                                : blockingObject.Reason.ToString();
+
+                _context.Write("{0}| {1} ", new string(' ', (depth + 1) * 2), reason);
 
                 if (!String.IsNullOrEmpty(blockingObject.KernelObjectName))
                 {
@@ -206,6 +210,8 @@ namespace msos
 
                         UnifiedBlockingObject blockingObject;
                         if (_stackWalker.GetCriticalSectionBlockingObject(frame, out blockingObject))
+                            result.Add(blockingObject);
+                        else if (_stackWalker.GetThreadSleepBlockingObject(frame, out blockingObject))
                             result.Add(blockingObject);
 
                         result.AddRange(frame.Handles.Select(GetUnifiedBlockingObjectForHandle));

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace msos
 {
-    [SupportedTargets(TargetType.DumpFile, TargetType.LiveProcess)]
+    [SupportedTargets(TargetType.DumpFile, TargetType.LiveProcess, TargetType.DumpFileNoHeap)]
     [Verb("!waits", HelpText = "Displays wait chain information and detects deadlocks.")]
     class WaitChains : ICommand
     {
@@ -56,7 +56,8 @@ namespace msos
 
         private void SetStrategy()
         {
-            if (_context.TargetType == TargetType.DumpFile)
+            if (_context.TargetType == TargetType.DumpFileNoHeap 
+                || _context.TargetType == TargetType.DumpFileNoHeap)
             {
                 _temporaryDbgEngTarget = _context.CreateTemporaryDbgEngTarget();
                 _unifiedStackTraces = new UnifiedStackTraces(_temporaryDbgEngTarget.DebuggerInterface, _context);

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -68,7 +68,7 @@ namespace msos
             else
             {
                 _blockingObjectsStrategy = new LiveProcessBlockingObjectsStrategy(_context.Runtime);
-
+                
                 // Currently, we are only enumerating the managed threads because we don't have 
                 // an alternative source of information for threads in live processes. In the future,
                 // we can consider using System.Diagnostics or some other means of enumerating threads

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -56,8 +56,7 @@ namespace msos
 
         private void SetStrategy()
         {
-            if (_context.TargetType == TargetType.DumpFile
-                || _context.TargetType == TargetType.DumpFile)
+            if (_context.TargetType == TargetType.DumpFile)
             {
                 _temporaryDbgEngTarget = _context.CreateTemporaryDbgEngTarget();
                 _unifiedStackTraces = new UnifiedStackTraces(_temporaryDbgEngTarget.DebuggerInterface, _context);

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -68,7 +68,7 @@ namespace msos
             else
             {
                 _blockingObjectsStrategy = new LiveProcessBlockingObjectsStrategy(_context.Runtime);
-                
+
                 // Currently, we are only enumerating the managed threads because we don't have 
                 // an alternative source of information for threads in live processes. In the future,
                 // we can consider using System.Diagnostics or some other means of enumerating threads
@@ -108,11 +108,7 @@ namespace msos
         {
             foreach (var blockingObject in unifiedThread.BlockingObjects)
             {
-                string reason = blockingObject.Type == UnifiedBlockingType.ThreadSleep
-                                ? $"ThreadSleep: {blockingObject.SleepWait.Value}"
-                                : blockingObject.Reason.ToString();
-
-                _context.Write("{0}| {1} ", new string(' ', (depth + 1) * 2), reason);
+                _context.Write("{0}| {1} {2}", new string(' ', (depth + 1) * 2), blockingObject.Reason, blockingObject.ReasonDescription);
 
                 if (!String.IsNullOrEmpty(blockingObject.KernelObjectName))
                 {

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -56,8 +56,7 @@ namespace msos
 
         private void SetStrategy()
         {
-            if (_context.TargetType == TargetType.DumpFile
-                || _context.TargetType == TargetType.DumpFile)
+            if (_context.TargetType == TargetType.DumpFile)
             {
                 _temporaryDbgEngTarget = _context.CreateTemporaryDbgEngTarget();
                 _unifiedStackTraces = new UnifiedStackTraces(_temporaryDbgEngTarget.DebuggerInterface, _context);
@@ -202,7 +201,10 @@ namespace msos
                     var stack = _unifiedStackTraces.GetStackTrace(threadInfo.EngineThreadId);
                     foreach (var frame in stack)
                     {
-                        _stackWalker.SetFrameParameters(frame);
+                        if (_stackWalker.SetFrameParameters(frame))
+                        {
+                            
+                        }
 
                         UnifiedBlockingObject blockingObject;
                         if (_stackWalker.GetCriticalSectionBlockingObject(frame, out blockingObject))

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -108,7 +108,7 @@ namespace msos
         {
             foreach (var blockingObject in unifiedThread.BlockingObjects)
             {
-                string reason = blockingObject.Reason == UnifiedBlockingReason.ThreadSleep
+                string reason = blockingObject.Type == UnifiedBlockingType.ThreadSleep
                                 ? $"ThreadSleep: {blockingObject.SleepWait.Value}"
                                 : blockingObject.Reason.ToString();
 

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace msos
 {
-    [SupportedTargets(TargetType.DumpFile, TargetType.LiveProcess)]
+    [SupportedTargets(TargetType.DumpFile, TargetType.LiveProcess, TargetType.DumpFileNoHeap)]
     [Verb("!waits", HelpText = "Displays wait chain information and detects deadlocks.")]
     class WaitChains : ICommand
     {
@@ -57,7 +57,7 @@ namespace msos
         private void SetStrategy()
         {
             if (_context.TargetType == TargetType.DumpFile
-                || _context.TargetType == TargetType.DumpFile)
+                || _context.TargetType == TargetType.DumpFileNoHeap)
             {
                 _temporaryDbgEngTarget = _context.CreateTemporaryDbgEngTarget();
                 _unifiedStackTraces = new UnifiedStackTraces(_temporaryDbgEngTarget.DebuggerInterface, _context);

--- a/msos/WaitChains.cs
+++ b/msos/WaitChains.cs
@@ -67,7 +67,7 @@ namespace msos
             else
             {
                 _blockingObjectsStrategy = new LiveProcessBlockingObjectsStrategy(_context.Runtime);
-                
+
                 // Currently, we are only enumerating the managed threads because we don't have 
                 // an alternative source of information for threads in live processes. In the future,
                 // we can consider using System.Diagnostics or some other means of enumerating threads
@@ -107,7 +107,10 @@ namespace msos
         {
             foreach (var blockingObject in unifiedThread.BlockingObjects)
             {
-                _context.Write("{0}| {1} ", new string(' ', (depth + 1) * 2), blockingObject.Reason);
+                string reason = blockingObject.Reason == UnifiedBlockingReason.ThreadSleep
+                                ? $"ThreadSleep {blockingObject.Handle}" : blockingObject.Reason.ToString();
+
+                _context.Write("{0}| {1} ", new string(' ', (depth + 1) * 2), reason);
 
                 if (!String.IsNullOrEmpty(blockingObject.KernelObjectName))
                 {
@@ -201,11 +204,8 @@ namespace msos
                     var stack = _unifiedStackTraces.GetStackTrace(threadInfo.EngineThreadId);
                     foreach (var frame in stack)
                     {
-                        if (_stackWalker.SetFrameParameters(frame))
-                        {
+                        _stackWalker.SetFrameParameters(frame);
                             
-                        }
-
                         UnifiedBlockingObject blockingObject;
                         if (_stackWalker.GetCriticalSectionBlockingObject(frame, out blockingObject))
                             result.Add(blockingObject);
@@ -229,7 +229,7 @@ namespace msos
         protected virtual UnifiedBlockingObject GetUnifiedBlockingObjectForHandle(UnifiedHandle handle)
         {
             return new UnifiedBlockingObject(handle.Value, handle.ObjectName, handle.Type);
-        }
+        }   
     }
 
 


### PR DESCRIPTION
Detecting `Thread.Sleep` and Win32 `Sleep/SleepEx` as blocking objects by inspecting for NtDelayExecution function. Same flow  as we do with CriticalSections 