### PR TITLE
Disassemble command improvements

### DIFF
--- a/ClrMemDiagExt/ClrSourceExtensions.cs
+++ b/ClrMemDiagExt/ClrSourceExtensions.cs
@@ -68,6 +68,8 @@ namespace Microsoft.Diagnostics.RuntimeExt
                         nearest.LineNumberEnd = (int)point.LineEnd;
                         nearest.ColStart = (int)point.ColBegin;
                         nearest.ColEnd = (int)point.ColEnd;
+
+                        distance = dist;
                     }
                 }
             }

--- a/msos/Disassemble.cs
+++ b/msos/Disassemble.cs
@@ -101,8 +101,13 @@ namespace msos
                         sourceLocation.ColStart, sourceLocation.ColEnd);
                     for (int line = sourceLocation.LineNumber; line <= sourceLocation.LineNumberEnd; ++line)
                     {
-                        _context.WriteLine(ReadSourceLine(sourceLocation.FilePath, line));
-                        _context.WriteLine(new string(' ', sourceLocation.ColStart - 1) + new string('^', sourceLocation.ColEnd - sourceLocation.ColStart));
+                        var sourceLine = ReadSourceLine(sourceLocation.FilePath, line);
+
+                        if (sourceLine != null)
+                        {
+                            _context.WriteLine(sourceLine);
+                            _context.WriteLine(new string(' ', sourceLocation.ColStart - 1) + new string('^', sourceLocation.ColEnd - sourceLocation.ColStart));
+                        }
                     }
                 }
                 PrintInstructions(instructions);
@@ -120,7 +125,10 @@ namespace msos
                 contents = File.ReadAllLines(file);
                 _sourceFileCache.Add(file, contents);
             }
-            return contents[line - 1];
+
+            return line - 1 < contents.Length 
+                ? contents[line - 1]
+                : null;
         }
 
         private void PrintInstructions(IEnumerable<Instruction> instructions)


### PR DESCRIPTION
Hi!

I have been using part of the code of msos to display the disassembly code for BenchmarkDotNet and I have realized, that always the last line of source code was printed. 

The bug fix was trivial: when you find smaller distance, set the current distance to it. So far the value of distance was always int.Max, so the value of `if (dist < distance)` was always true, so the loop was going to the end, and returning the last line.

I also added more defensive way of looking for the source lines in the file, which can handle "nop" (clrmd reports some another magic number for it)

![image](https://user-images.githubusercontent.com/6011991/28676649-793ae0ec-72eb-11e7-9ed8-e80b1be1afa2.png)

I implemented the support for printing epilogue. It looks like always the first element of `method.ILOffsetMap` with `ILOffset == -2` is prolog, and the last one with `ILOffset == -3` is epilogue.
