### PR TITLE
replaced dependency on editbin.exe and VS2015-specific path with a LargeAddressAware NuGet package (#72)

### DIFF
--- a/msos/msos.csproj
+++ b/msos/msos.csproj
@@ -306,13 +306,17 @@ foreach (var item in filesToCleanup)
     <PostBuildEvent Condition="'$(Platform)' == 'x86' And '$(Configuration)' == 'Release-NoCostura'">xcopy /Y /F "$(ProjectDir)"costura32\*.dll .</PostBuildEvent>
     <PostBuildEvent Condition="'$(Platform)' == 'x64' And '$(Configuration)' == 'Release-NoCostura'">xcopy /Y /F "$(ProjectDir)"costura64\*.dll .</PostBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\Costura.Fody.2.0.0-beta0018\build\Costura.Fody.targets" Condition="Exists('..\packages\Costura.Fody.2.0.0-beta0018\build\Costura.Fody.targets') And '$(Configuration)' != 'Release-NoCostura'" />
+  <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets') And '$(Configuration)' != 'Release-NoCostura'" />
+  
+  <Import Project="..\packages\LargeAddressAware.1.0.1\build\LargeAddressAware.targets" Condition="Exists('..\packages\LargeAddressAware.1.0.1\build\LargeAddressAware.targets')" />
   <PropertyGroup Condition="'$(Platform)' == 'x86'">
     <LargeAddressAware>true</LargeAddressAware>
   </PropertyGroup>
-  <Import Project="..\packages\Costura.Fody.2.0.0-beta0018\build\Costura.Fody.targets" Condition="Exists('..\packages\Costura.Fody.2.0.0-beta0018\build\Costura.Fody.targets') And '$(Configuration)' != 'Release-NoCostura'" />
-  <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets') And '$(Configuration)' != 'Release-NoCostura'" />
-  <Import Project="..\packages\LargeAddressAware.1.0.1\build\LargeAddressAware.targets" Condition="Exists('..\packages\LargeAddressAware.1.0.1\build\LargeAddressAware.targets')" />
-  
+  <Target Name="CustomSetLargeAddressAware" AfterTargets="FodyTarget" Condition="'$(LargeAddressAware)' == 'true' AND Exists('$(EditBin)')">
+    <Exec Command='"$(EditBin)" "@(IntermediateAssembly)"' />
+  </Target>
+
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/msos/msos.csproj
+++ b/msos/msos.csproj
@@ -264,6 +264,7 @@
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\Costura.Fody.2.0.0-beta0018\build\Costura.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Costura.Fody.2.0.0-beta0018\build\Costura.Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\dotnet\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\LargeAddressAware.1.0.1\build\LargeAddressAware.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LargeAddressAware.1.0.1\build\LargeAddressAware.targets'))" />
   </Target>
   <UsingTask TaskName="CosturaCleanup" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" TaskFactory="CodeTaskFactory">
     <ParameterGroup>
@@ -302,13 +303,16 @@ foreach (var item in filesToCleanup)
     <CosturaCleanup Config="FodyWeavers.xml" Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" Condition="'$(Configuration)' != 'Release-NoCostura'" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\vsvars32.bat"
-editbin /largeaddressaware "$(TargetPath)"</PostBuildEvent>
-	<PostBuildEvent Condition="'$(Platform)' == 'x86' And '$(Configuration)' == 'Release-NoCostura'">xcopy /Y /F "$(ProjectDir)"costura32\*.dll .</PostBuildEvent>
-	<PostBuildEvent Condition="'$(Platform)' == 'x64' And '$(Configuration)' == 'Release-NoCostura'">xcopy /Y /F "$(ProjectDir)"costura64\*.dll .</PostBuildEvent>
+    <PostBuildEvent Condition="'$(Platform)' == 'x86' And '$(Configuration)' == 'Release-NoCostura'">xcopy /Y /F "$(ProjectDir)"costura32\*.dll .</PostBuildEvent>
+    <PostBuildEvent Condition="'$(Platform)' == 'x64' And '$(Configuration)' == 'Release-NoCostura'">xcopy /Y /F "$(ProjectDir)"costura64\*.dll .</PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'x86'">
+    <LargeAddressAware>true</LargeAddressAware>
   </PropertyGroup>
   <Import Project="..\packages\Costura.Fody.2.0.0-beta0018\build\Costura.Fody.targets" Condition="Exists('..\packages\Costura.Fody.2.0.0-beta0018\build\Costura.Fody.targets') And '$(Configuration)' != 'Release-NoCostura'" />
   <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets') And '$(Configuration)' != 'Release-NoCostura'" />
+  <Import Project="..\packages\LargeAddressAware.1.0.1\build\LargeAddressAware.targets" Condition="Exists('..\packages\LargeAddressAware.1.0.1\build\LargeAddressAware.targets')" />
+  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/msos/packages.config
+++ b/msos/packages.config
@@ -4,6 +4,7 @@
   <package id="Fody" version="1.29.4" targetFramework="net46" developmentDependency="true" />
   <package id="ICSharpCode.Decompiler" version="2.3.1" targetFramework="net45" />
   <package id="ICSharpCode.NRefactory" version="5.5.1" targetFramework="net45" />
+  <package id="LargeAddressAware" version="1.0.1" targetFramework="net46" />
   <package id="Microsoft.Diagnostics.Runtime" version="0.8.31" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
   <package id="NetSerializer" version="3.0.0.0" targetFramework="net45" />


### PR DESCRIPTION
Instead of determining where to find `editbin.exe` locally depending on VS version, I hope I found a more elegant solution: [LargeAddressAware](https://www.nuget.org/packages/LargeAddressAware/) Nuget package by Kirill Osenkov (sources are [here](https://github.com/KirillOsenkov/LargeAddressAware)). Since this is only required for 32-bit builds, I have added this condition when setting the `<LargeAddressAware>` property, which triggers the execution of the tool.

I don't really know how to verify the resulting executable, but at least I tested that it the tool from the package is indeed being run according to this logic. Funnily enough, verifying this was made super-easy by virtue of *MSBuild Structured Log Viewer*, built by Kirill Osenkov too. :) So, thanks to him!